### PR TITLE
Improve OTP alert and add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Helper extension for KeePass to find and insert credentials, generate passwords,
   * Edge: https://microsoftedge.microsoft.com/addons/detail/bfmglfdehkodoiinbclgoppembjfgjkj
   * Firefox: https://addons.mozilla.org/firefox/addon/keepasshelper/
   * Opera: https://addons.opera.com/extensions/details/keepasshelper/
+
+### Building
+
+Run `./build.sh` to create a `keepass-helper.zip` package from the `v3` folder.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Build KeePassHelper extension from v3 directory
+rm -f keepass-helper.zip
+cd v3
+zip -r ../keepass-helper.zip . -x '*.DS_Store'

--- a/v3/data/cmd/index.js
+++ b/v3/data/cmd/index.js
@@ -14,7 +14,7 @@ let usernames = [];
 
 const timebased = {
   words: {
-    otp: ['KPH: otp', 'KPH:otp', 'otp'],
+    otp: ['KPH: otp', 'KPH:otp', 'otp', 'KPOTP'],
     sotp: ['KPH: sotp', 'KPH:sotp', 'sotp'],
     botp: ['TimeOtp-Secret-Base32']
   },
@@ -679,9 +679,9 @@ document.addEventListener('click', async e => {
           await copy(s);
         }
         else {
-          alert(`No string-field entry with either "otp" or "sotp" key is detected.
+          alert(`No string-field entry with either "otp", "KPOTP" or "sotp" key is detected.
 
-  To generate one-time password tokens, save a new string-field entry with "KPH: otp" name and SECRET as value.`);
+  To generate one-time password tokens, save a new string-field entry with "KPOTP" or "KPH: otp" name and SECRET as value.`);
         }
       }
       catch (e) {


### PR DESCRIPTION
## Summary
- mention KPOTP in OTP message
- add build script for packaging extension
- document build instructions

## Testing
- `npm test` *(fails: could not find package.json)*
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884b90624088330966708d2d9d82c93